### PR TITLE
Добавил логирование для DAO и заменил печать в консоль

### DIFF
--- a/Group_Work_2_DAO_Hibernate/pom.xml
+++ b/Group_Work_2_DAO_Hibernate/pom.xml
@@ -82,6 +82,21 @@
             <artifactId>liquibase-maven-plugin</artifactId>
             <version>4.30.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.24.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.24.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Group_Work_2_DAO_Hibernate/pom.xml
+++ b/Group_Work_2_DAO_Hibernate/pom.xml
@@ -83,16 +83,6 @@
             <version>4.30.0</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.24.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.24.2</version>

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/DeleteCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/DeleteCommand.java
@@ -4,26 +4,31 @@ import itacademy.api.Creator;
 import itacademy.api.DAO;
 import itacademy.api.Command;
 import itacademy.exceptions.checked.InvalidInputException;
-import itacademy.utils.DataOutputUtils;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 
 public abstract class DeleteCommand<T> implements Command {
+    private static final String ROW_DELETED = "Запись с id {} удалена";
+    private static final String ROW_NOT_FOUND = "Запись с id {} не найдена!";
+    private final Logger logger;
+
     private final DAO<T> dao;
     private final Creator<Serializable> idCreator;
 
-    public DeleteCommand(DAO<T> dao, Creator<Serializable> idCreator) {
+    public DeleteCommand(DAO<T> dao, Creator<Serializable> idCreator, Logger logger) {
         this.dao = dao;
         this.idCreator = idCreator;
+        this.logger = logger;
     }
 
     @Override
     public void execute() throws InvalidInputException {
         Serializable id = this.idCreator.create();
         if (this.dao.delete(id)) {
-            DataOutputUtils.displayMessage("Запись с id " + id + " удалена");
+            this.logger.debug(ROW_DELETED, id);
         } else {
-            DataOutputUtils.displayMessage("Запись с id " + id + " не найдена!");
+            this.logger.debug(ROW_NOT_FOUND, id);
         }
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/SaveCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/SaveCommand.java
@@ -5,26 +5,29 @@ import itacademy.api.DAO;
 import itacademy.api.Command;
 import itacademy.api.Printer;
 import itacademy.exceptions.checked.InvalidInputException;
-import itacademy.utils.DataOutputUtils;
 import itacademy.utils.ReflectionUtils;
+import org.slf4j.Logger;
 
 public abstract class SaveCommand<T> implements Command {
+    private static final String ROW_SAVED_MESSAGE = "В таблицу {} добавлена запись";
+
     private final DAO<T> dao;
     private final Creator<T> entityCreator;
     private final Printer<T> printer;
+    private final Logger logger;
 
-    public SaveCommand(DAO<T> dao, Creator<T> entityCreator, Printer<T> printer) {
+    public SaveCommand(DAO<T> dao, Creator<T> entityCreator, Printer<T> printer, Logger logger) {
         this.dao = dao;
         this.entityCreator = entityCreator;
         this.printer = printer;
+        this.logger = logger;
     }
 
     @Override
     public void execute() throws InvalidInputException, IllegalAccessException {
         T entity = this.entityCreator.create();
-        DataOutputUtils.displayMessage("В таблицу "
-                + ReflectionUtils.getTableNameByClass(entity.getClass())
-                + " добавлена запись");
-        printer.printEntity(this.dao.save(entity));
+        this.dao.save(entity);
+        this.logger.debug(ROW_SAVED_MESSAGE, ReflectionUtils.getTableNameByClass(entity.getClass()));
+        printer.printEntity(entity);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/UpdateCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/UpdateCommand.java
@@ -4,20 +4,25 @@ import itacademy.api.Creator;
 import itacademy.api.DAO;
 import itacademy.api.Command;
 import itacademy.exceptions.checked.InvalidInputException;
-import itacademy.utils.DataOutputUtils;
 import itacademy.utils.ReflectionUtils;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 
 public abstract class UpdateCommand<T> implements Command {
+    private static final String ROW_UPDATED = "Запись с id {} в таблице {} обновлена.";
+    private static final String ROW_NOT_FOUND = "Запись с id {} не найдена!";
+
     private final DAO<T> dao;
     private final Creator<T> entityCreator;
     private final Creator<Serializable> idCreator;
+    private final Logger logger;
 
-    public UpdateCommand(DAO<T> dao, Creator<T> entityCreator, Creator<Serializable> idCreator) {
+    public UpdateCommand(DAO<T> dao, Creator<T> entityCreator, Creator<Serializable> idCreator, Logger logger) {
         this.dao = dao;
         this.entityCreator = entityCreator;
         this.idCreator = idCreator;
+        this.logger = logger;
     }
 
     @Override
@@ -26,11 +31,9 @@ public abstract class UpdateCommand<T> implements Command {
         T entity = this.entityCreator.create();
 
         if (this.dao.update(id, entity) != null) {
-            DataOutputUtils.displayMessage("Запись с id " + id
-            + " в таблице " + ReflectionUtils.getTableNameByClass(entity.getClass())
-            + " обновлена.");
+            logger.debug(ROW_UPDATED, id, ReflectionUtils.getTableNameByClass(entity.getClass()));
         } else {
-            DataOutputUtils.displayMessage("Запись с id " + id + " не найдена!");
+            logger.debug(ROW_NOT_FOUND, id);
         }
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressDeleteCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressDeleteCommand.java
@@ -4,10 +4,13 @@ import itacademy.api.AddressDAO;
 import itacademy.commands.DeleteCommand;
 import itacademy.creators.IdCreator;
 import itacademy.entity.Address;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressDeleteCommand extends DeleteCommand<Address> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AddressDeleteCommand.class);
 
     public AddressDeleteCommand(AddressDAO dao) {
-        super(dao, new IdCreator());
+        super(dao, new IdCreator(LOGGER), LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressGetAllCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressGetAllCommand.java
@@ -4,10 +4,13 @@ import itacademy.api.AddressDAO;
 import itacademy.commands.GetAllCommand;
 import itacademy.entity.Address;
 import itacademy.printers.impl.AddressPrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressGetAllCommand extends GetAllCommand<Address> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AddressGetAllCommand.class);
 
     public AddressGetAllCommand(AddressDAO dao) {
-        super(dao, new AddressPrinter());
+        super(dao, new AddressPrinter(LOGGER));
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressGetCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressGetCommand.java
@@ -5,10 +5,13 @@ import itacademy.commands.GetCommand;
 import itacademy.creators.IdCreator;
 import itacademy.entity.Address;
 import itacademy.printers.impl.AddressPrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressGetCommand extends GetCommand<Address> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AddressGetCommand.class);
 
     public AddressGetCommand(AddressDAO dao) {
-        super(dao, new IdCreator(), new AddressPrinter());
+        super(dao, new IdCreator(LOGGER), new AddressPrinter(LOGGER));
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressSaveCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressSaveCommand.java
@@ -5,10 +5,13 @@ import itacademy.commands.SaveCommand;
 import itacademy.creators.AddressCreator;
 import itacademy.entity.Address;
 import itacademy.printers.impl.AddressPrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressSaveCommand extends SaveCommand<Address> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AddressSaveCommand.class);
 
     public AddressSaveCommand(AddressDAO dao) {
-        super(dao, new AddressCreator(), new AddressPrinter());
+        super(dao, new AddressCreator(LOGGER), new AddressPrinter(LOGGER), LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressUpdateCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/address/AddressUpdateCommand.java
@@ -5,10 +5,13 @@ import itacademy.commands.UpdateCommand;
 import itacademy.creators.AddressCreator;
 import itacademy.creators.IdCreator;
 import itacademy.entity.Address;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AddressUpdateCommand extends UpdateCommand<Address> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AddressUpdateCommand.class);
 
     public AddressUpdateCommand(AddressDAO dao) {
-        super(dao, new AddressCreator(), new IdCreator());
+        super(dao, new AddressCreator(LOGGER), new IdCreator(LOGGER), LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleDeleteCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleDeleteCommand.java
@@ -4,10 +4,13 @@ import itacademy.api.PeopleDAO;
 import itacademy.commands.DeleteCommand;
 import itacademy.creators.IdCreator;
 import itacademy.entity.People;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PeopleDeleteCommand extends DeleteCommand<People> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PeopleDeleteCommand.class);
 
     public PeopleDeleteCommand(PeopleDAO dao) {
-        super(dao, new IdCreator());
+        super(dao, new IdCreator(LOGGER), LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleGetAllCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleGetAllCommand.java
@@ -4,10 +4,13 @@ import itacademy.api.PeopleDAO;
 import itacademy.commands.GetAllCommand;
 import itacademy.entity.People;
 import itacademy.printers.impl.PeoplePrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PeopleGetAllCommand extends GetAllCommand<People> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PeopleGetAllCommand.class);
 
     public PeopleGetAllCommand(PeopleDAO dao) {
-        super(dao, new PeoplePrinter());
+        super(dao, new PeoplePrinter(LOGGER));
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleGetCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleGetCommand.java
@@ -5,10 +5,13 @@ import itacademy.commands.GetCommand;
 import itacademy.creators.IdCreator;
 import itacademy.entity.People;
 import itacademy.printers.impl.PeoplePrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PeopleGetCommand extends GetCommand<People> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PeopleGetCommand.class);
 
     public PeopleGetCommand(PeopleDAO dao) {
-        super(dao, new IdCreator(), new PeoplePrinter());
+        super(dao, new IdCreator(LOGGER), new PeoplePrinter(LOGGER));
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleSaveCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleSaveCommand.java
@@ -5,10 +5,13 @@ import itacademy.commands.SaveCommand;
 import itacademy.creators.PeopleCreator;
 import itacademy.entity.People;
 import itacademy.printers.impl.PeoplePrinter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PeopleSaveCommand extends SaveCommand<People> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PeopleSaveCommand.class);
 
     public PeopleSaveCommand(PeopleDAO dao) {
-        super(dao, new PeopleCreator(), new PeoplePrinter());
+        super(dao, new PeopleCreator(LOGGER), new PeoplePrinter(LOGGER), LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleUpdateCommand.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/commands/people/PeopleUpdateCommand.java
@@ -5,10 +5,13 @@ import itacademy.commands.UpdateCommand;
 import itacademy.creators.IdCreator;
 import itacademy.creators.PeopleCreator;
 import itacademy.entity.People;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PeopleUpdateCommand extends UpdateCommand<People> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PeopleUpdateCommand.class);
 
     public PeopleUpdateCommand(PeopleDAO dao) {
-        super(dao, new PeopleCreator(), new IdCreator());
+        super(dao, new PeopleCreator(LOGGER), new IdCreator(LOGGER), LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/creators/AddressCreator.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/creators/AddressCreator.java
@@ -4,18 +4,23 @@ import itacademy.api.Creator;
 import itacademy.entity.Address;
 import itacademy.exceptions.checked.InvalidInputException;
 import itacademy.utils.ConsoleUtils;
-import itacademy.utils.DataOutputUtils;
+import org.slf4j.Logger;
 
 public class AddressCreator implements Creator<Address> {
     private static final String REQUEST_STREET_ENTRY = "Введите название улицы: ";
     private static final String REQUEST_HOUSE_ENTRY = "Введите номер дома: ";
+    private final Logger logger;
+
+    public AddressCreator(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public Address create() throws InvalidInputException {
-        DataOutputUtils.displayMessage(REQUEST_STREET_ENTRY);
+        this.logger.debug(REQUEST_STREET_ENTRY);
         ConsoleUtils.inputString();
         String street = ConsoleUtils.inputString();
-        DataOutputUtils.displayMessage(REQUEST_HOUSE_ENTRY);
+        this.logger.debug(REQUEST_HOUSE_ENTRY);
         int house = ConsoleUtils.inputInt();
 
         return Address.builder()

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/creators/IdCreator.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/creators/IdCreator.java
@@ -3,16 +3,21 @@ package itacademy.creators;
 import itacademy.api.Creator;
 import itacademy.exceptions.checked.InvalidInputException;
 import itacademy.utils.ConsoleUtils;
-import itacademy.utils.DataOutputUtils;
+import org.slf4j.Logger;
 
 import java.io.Serializable;
 
 public class IdCreator implements Creator<Serializable> {
-    public static final String REQUEST_ID_ENTRY = "Введите id: ";
+    private static final String REQUEST_ID_ENTRY = "Введите id: ";
+    private final Logger logger;
+
+    public IdCreator(Logger logger) {
+        this.logger = logger;
+    }
 
     @Override
     public Serializable create() throws InvalidInputException {
-        DataOutputUtils.displayMessage(REQUEST_ID_ENTRY);
+        this.logger.debug(REQUEST_ID_ENTRY);
         return ConsoleUtils.inputInt();
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/creators/PeopleCreator.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/creators/PeopleCreator.java
@@ -4,21 +4,27 @@ import itacademy.api.Creator;
 import itacademy.entity.People;
 import itacademy.exceptions.checked.InvalidInputException;
 import itacademy.utils.ConsoleUtils;
-import itacademy.utils.DataOutputUtils;
+import org.slf4j.Logger;
 
 public class PeopleCreator implements Creator<People> {
     public static final String REQUEST_NAME_ENTRY = "Введите имя: ";
     public static final String REQUEST_SURNAME_ENTRY = "Введите фамилию: ";
     public static final String REQUEST_AGE_ENTRY = "Введите возраст: ";
 
+    private final Logger logger;
+
+    public PeopleCreator(Logger logger) {
+        this.logger = logger;
+    }
+
     @Override
     public People create() throws InvalidInputException {
-        DataOutputUtils.displayMessage(REQUEST_NAME_ENTRY);
+        this.logger.debug(REQUEST_NAME_ENTRY);
         ConsoleUtils.inputString();
         String name = ConsoleUtils.inputString();
-        DataOutputUtils.displayMessage(REQUEST_SURNAME_ENTRY);
+        this.logger.debug(REQUEST_SURNAME_ENTRY);
         String surname = ConsoleUtils.inputString();
-        DataOutputUtils.displayMessage(REQUEST_AGE_ENTRY);
+        this.logger.debug(REQUEST_AGE_ENTRY);
         int age = ConsoleUtils.inputInt();
 
         return People.builder()

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/dao/impl/AddressDAOImpl.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/dao/impl/AddressDAOImpl.java
@@ -3,6 +3,8 @@ package itacademy.dao.impl;
 import itacademy.api.AddressDAO;
 import itacademy.dao.UniversalDAO;
 import itacademy.entity.Address;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Класс {@code AddressDAOImpl} наследуется от абстрактного класса {@code UniversalDAO} для того,
@@ -10,12 +12,13 @@ import itacademy.entity.Address;
  * реализует дополнительные методы из интерфейса {@code AddressDAO}, уникальные для класса DTO {@code Address}.
  */
 public class AddressDAOImpl extends UniversalDAO<Address> implements AddressDAO {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AddressDAOImpl.class);
 
     /**
      * Этот конструктор передает в конструктор родительского класса {@code UniversalDAO} класс DTO {@code Address},
      * чтобы через рефлексию получить доступ к полям и аннотациями класса DTO {@code Address}.
      */
     public AddressDAOImpl() {
-        super(Address.class);
+        super(Address.class, LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/dao/impl/PeopleDAOImpl.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/dao/impl/PeopleDAOImpl.java
@@ -3,6 +3,8 @@ package itacademy.dao.impl;
 import itacademy.api.PeopleDAO;
 import itacademy.dao.UniversalDAO;
 import itacademy.entity.People;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Класс {@code PeopleDAOImpl} наследуется от абстрактного класса {@code UniversalDAO} для того,
@@ -10,12 +12,13 @@ import itacademy.entity.People;
  * реализует дополнительные методы из интерфейса {@code PeopleDAO}, уникальные для класса DTO {@code People}.
  */
 public class PeopleDAOImpl extends UniversalDAO<People> implements PeopleDAO {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PeopleDAOImpl.class);
 
     /**
      * Этот конструктор передает в конструктор родительского класса {@code UniversalDAO} класс DTO {@code People},
      * чтобы через рефлексию получить доступ к полям и аннотациями класса DTO {@code People}.
      */
     public PeopleDAOImpl() {
-        super(People.class);
+        super(People.class,LOGGER);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/printers/UniversalPrinter.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/printers/UniversalPrinter.java
@@ -3,6 +3,7 @@ package itacademy.printers;
 import itacademy.api.Printer;
 import itacademy.utils.DataOutputUtils;
 import itacademy.utils.ReflectionUtils;
+import org.slf4j.Logger;
 
 import java.util.List;
 
@@ -18,9 +19,11 @@ public abstract class UniversalPrinter<T> implements Printer<T> {
     private static final String NOT_FOUND = "Запись с таким id не найдена!";
 
     private final Class<T> clazz;
+    private final Logger logger;
 
-    public UniversalPrinter(Class<T> clazz) {
+    public UniversalPrinter(Class<T> clazz, Logger logger) {
         this.clazz = clazz;
+        this.logger = logger;
     }
 
     @Override
@@ -28,9 +31,9 @@ public abstract class UniversalPrinter<T> implements Printer<T> {
         if (entity != null) {
             this.printHeader();
             this.printOneEntity(entity);
-            DataOutputUtils.displayMessage(this.getLine());
+            this.logger.debug(this.getLine());
         } else {
-            DataOutputUtils.displayMessage(NOT_FOUND);
+            this.logger.debug(NOT_FOUND);
         }
 
     }
@@ -41,7 +44,7 @@ public abstract class UniversalPrinter<T> implements Printer<T> {
         for (T entity : entities) {
             this.printOneEntity(entity);
         }
-        DataOutputUtils.displayMessage(this.getLine());
+        this.logger.debug(this.getLine());
     }
 
     @Override
@@ -54,7 +57,7 @@ public abstract class UniversalPrinter<T> implements Printer<T> {
                 NEW_LINE +
                 this.getLine();
 
-        DataOutputUtils.displayMessage(headerBuilder);
+        this.logger.debug(headerBuilder);
     }
 
     private String getLine() {
@@ -90,6 +93,6 @@ public abstract class UniversalPrinter<T> implements Printer<T> {
 
     private void printOneEntity(T entity) throws IllegalAccessException {
         List<String> values = ReflectionUtils.getColumnsValues(entity);
-        DataOutputUtils.displayMessage(this.getTableRow(values));
+        this.logger.debug(this.getTableRow(values));
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/printers/impl/AddressPrinter.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/printers/impl/AddressPrinter.java
@@ -3,10 +3,11 @@ package itacademy.printers.impl;
 import itacademy.api.Printer;
 import itacademy.entity.Address;
 import itacademy.printers.UniversalPrinter;
+import org.slf4j.Logger;
 
 public class AddressPrinter extends UniversalPrinter<Address> implements Printer<Address> {
 
-    public AddressPrinter() {
-        super(Address.class);
+    public AddressPrinter(Logger logger) {
+        super(Address.class, logger);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/printers/impl/PeoplePrinter.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/printers/impl/PeoplePrinter.java
@@ -3,10 +3,11 @@ package itacademy.printers.impl;
 import itacademy.api.Printer;
 import itacademy.entity.People;
 import itacademy.printers.UniversalPrinter;
+import org.slf4j.Logger;
 
 public class PeoplePrinter extends UniversalPrinter<People> implements Printer<People> {
 
-    public PeoplePrinter() {
-        super(People.class);
+    public PeoplePrinter(Logger logger) {
+        super(People.class, logger);
     }
 }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/utils/DataOutputUtils.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/utils/DataOutputUtils.java
@@ -2,14 +2,6 @@ package itacademy.utils;
 
 public class DataOutputUtils {
     /**
-     * Метод для вывода сообщения в консоль
-     * @param message сообщение
-     */
-    public static void displayMessage(String message) {
-        System.out.println(message);
-    }
-
-    /**
      * Метод обрезает строку, если она длиннее ширины столбца таблицы
      * @param str строка, которая проверяется
      * @param maxlength ширина столбца

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/utils/ExecutorUtils.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/utils/ExecutorUtils.java
@@ -1,10 +1,13 @@
 package itacademy.utils;
 
 import itacademy.api.HibernateExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.persistence.EntityManager;
 
 public class ExecutorUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutorUtils.class);
     /**
      * Метод для сокращения повторяющегося кода
      * Начинает транзакцию и делает коммит, если операция с БД прошла успешно
@@ -21,10 +24,12 @@ public class ExecutorUtils {
             entityManager.getTransaction().begin();
             T t = hibernateExecutor.execute(entityManager);
             entityManager.getTransaction().commit();
+            LOGGER.info("Transaction completed successfully");
 
             return t;
         } catch (Exception e) {
             entityManager.getTransaction().rollback();
+            LOGGER.error("Error executing transaction", e);
             return null;
         }
     }

--- a/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/utils/MenuUtils.java
+++ b/Group_Work_2_DAO_Hibernate/src/main/java/itacademy/utils/MenuUtils.java
@@ -18,8 +18,12 @@ import itacademy.dao.impl.PeopleDAOImpl;
 import itacademy.exceptions.checked.InvalidInputException;
 import itacademy.menu.Menu;
 import itacademy.menu.MenuItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MenuUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MenuUtils.class);
+
     /**
      * Метод создает и возвращает меню для работы с entity People
      * @return меню
@@ -65,7 +69,7 @@ public class MenuUtils {
 
         while (!isExit) {
             try {
-                DataOutputUtils.displayMessage(menu.toString());
+                LOGGER.debug(menu.toString());
                 int choice = ConsoleUtils.inputInt();
                 if (choice == 0) {
                     isExit = true;
@@ -74,10 +78,10 @@ public class MenuUtils {
                 if (item != null) {
                     item.executeCommand();
                 } else {
-                    DataOutputUtils.displayMessage("Такого пункта меню нет!");
+                    LOGGER.debug("Такого пункта меню нет!");
                 }
             } catch (InvalidInputException | IllegalAccessException e) {
-                DataOutputUtils.displayMessage(e.getMessage());
+                LOGGER.error(e.getMessage());
             }
         }
     }

--- a/Group_Work_2_DAO_Hibernate/src/main/resources/META-INF/persistence.xml
+++ b/Group_Work_2_DAO_Hibernate/src/main/resources/META-INF/persistence.xml
@@ -5,14 +5,12 @@
     <persistence-unit name="academy">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <properties>
-            <property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver"/>
+            <property name="javax.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver"/>
             <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/group_hw"/>
             <property name="javax.persistence.jdbc.user" value="root"/>
             <property name="javax.persistence.jdbc.password" value="123456"/>
             <property name="hibernate.dialect.storage_engine" value="innodb"/>
             <property name="hibernate.hbm2ddl.auto" value="validate"/>
-            <property name="hibernate.use_sql_comments" value="false"/>
-            <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.connection.pool_size" value="10"/>
             <property name="hibernate.connection.isolation" value="2"/>
         </properties>

--- a/Group_Work_2_DAO_Hibernate/src/main/resources/log4j2.xml
+++ b/Group_Work_2_DAO_Hibernate/src/main/resources/log4j2.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns="https://logging.apache.org/xml/ns"
+               xsi:schemaLocation="
+                       https://logging.apache.org/xml/ns
+                       https://logging.apache.org/xml/ns/log4j-config-2.xsd">
+
+    <Appenders>
+        <Console name="CONSOLE">
+            <PatternLayout pattern="[ %-5level] %d{HH:mm:ss} | %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile name="RollingFile"
+                     filePattern="Group_Work_2_DAO_Hibernate/logs/$${date:yyyy-MM}/app-%d{dd-MM-yyyy}-%i.log">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss} | %c | %msg%n%throwable"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="1 MB"/>
+            </Policies>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="itacademy.dao" level="INFO" additivity="false">
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+        <Logger name="itacademy.utils.ExecutorUtils" level="INFO" additivity="false">
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+        <Logger name="org.hibernate" level="INFO" additivity="false">
+            <AppenderRef ref="RollingFile" />
+        </Logger>
+        <Logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+            <AppenderRef ref="RollingFile" />
+        </Logger>
+        <Root level="ERROR">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="RollingFile"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/Group_Work_2_DAO_Hibernate/src/main/resources/log4j2.xml
+++ b/Group_Work_2_DAO_Hibernate/src/main/resources/log4j2.xml
@@ -9,9 +9,12 @@
         <Console name="CONSOLE">
             <PatternLayout pattern="[ %-5level] %d{HH:mm:ss} | %logger{36} - %msg%n"/>
         </Console>
+        <Console name="CONSOLE_APP">
+            <PatternLayout pattern="%msg%n"/>
+        </Console>
         <RollingFile name="RollingFile"
                      filePattern="Group_Work_2_DAO_Hibernate/logs/$${date:yyyy-MM}/app-%d{dd-MM-yyyy}-%i.log">
-            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss} | %c | %msg%n%throwable"/>
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss} | %c - %msg%n%throwable"/>
             <Policies>
                 <TimeBasedTriggeringPolicy />
                 <SizeBasedTriggeringPolicy size="1 MB"/>
@@ -31,6 +34,12 @@
         </Logger>
         <Logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
             <AppenderRef ref="RollingFile" />
+        </Logger>
+        <Logger name="itacademy.commands" level="DEBUG" additivity="false">
+            <AppenderRef ref="CONSOLE_APP"/>
+        </Logger>
+        <Logger name="itacademy.utils.MenuUtils" level="DEBUG" additivity="false">
+            <AppenderRef ref="CONSOLE_APP"/>
         </Logger>
         <Root level="ERROR">
             <AppenderRef ref="CONSOLE"/>


### PR DESCRIPTION
Для DAO сделал логирование только в файл, а для команд и принтеров просто заменил System.out.println на печать в консоль логов. Насколько я понял, Гена это имел ввиду, хз) Если это не нужно будет, то просто можно откатить коммит и оставить только для DAO. По сути как само логирование, то только для DAO оно и нужно. А то, что для приложения заменил это уже просто еще один способ вывода в печать. 